### PR TITLE
Fix JavaDoc accuracy in prereq/postreq/count classes 

### DIFF
--- a/src/main/java/seedu/pathlock/command/CountCommand.java
+++ b/src/main/java/seedu/pathlock/command/CountCommand.java
@@ -6,6 +6,9 @@ import seedu.pathlock.module.ModuleList;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+/**
+ * Displays the user's MC progress towards graduation.
+ */
 public class CountCommand extends Command {
 
     private static final Logger logger = Logger.getLogger(CountCommand.class.getName());

--- a/src/main/java/seedu/pathlock/module/ModuleList.java
+++ b/src/main/java/seedu/pathlock/module/ModuleList.java
@@ -32,9 +32,11 @@ public class ModuleList {
 
     /**
      * Returns the MC value for a given module code.
+     * Looks up both required and external modules.
      *
      * @param moduleCode Module code to look up.
-     * @return MC value, or 4 as default if not found.
+     * @return MC value of the module.
+     * @throws IllegalArgumentException If the module is not recognised.
      */
     public int getMcForModule(String moduleCode) {
         assert moduleCode != null : "Module code should not be null";
@@ -234,6 +236,9 @@ public class ModuleList {
 
     /**
      * Returns a summary of completed and remaining MCs with percentage.
+     *
+     * @return A formatted string showing completed MCs, remaining MCs,
+     *         and the percentage progress towards graduation.
      */
     public String countMcs() {
         int completedMcs = 0;


### PR DESCRIPTION
  - Correct "ModuleList.getMcForModule" JavaDoc (previously claimed it returned "4" as a default, but the method actually throws "IllegalArgumentException" for unrecognised modules)
  - Add missing @return tag to "ModuleList.countMcs"                                                                                          
  - Add class-level JavaDoc to "CountCommand" for consistency with "PrereqCommand" and "PostreqCommand"