### PR TITLE
Fix negative incomplete percentage when completed MCs exceed 160

### DIFF
--- a/src/main/java/seedu/pathlock/module/ModuleList.java
+++ b/src/main/java/seedu/pathlock/module/ModuleList.java
@@ -254,8 +254,9 @@ public class ModuleList {
         if (remainingMcs < 0) {
             remainingMcs = 0;
         }
-        double percentage = (double) completedMcs / TOTAL_GRADUATION_MCS * 100;
-        double remainingPercentage = 100.0 - percentage;
+        double percentage = Math.min(100.0,
+                (double) completedMcs / TOTAL_GRADUATION_MCS * 100);
+        double remainingPercentage = (double) remainingMcs / TOTAL_GRADUATION_MCS * 100;
 
         logger.log(Level.INFO, "MC progress: {0}/{1} MCs completed ({2}%)",
                 new Object[]{completedMcs, TOTAL_GRADUATION_MCS, String.format("%.1f", percentage)});

--- a/src/test/java/seedu/pathlock/command/CountCommandTest.java
+++ b/src/test/java/seedu/pathlock/command/CountCommandTest.java
@@ -8,6 +8,7 @@ import seedu.pathlock.module.ModuleList;
 import seedu.pathlock.planner.PlannerList;
 import seedu.pathlock.profile.UserProfile;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CountCommandTest {
@@ -96,5 +97,8 @@ public class CountCommandTest {
         String result = cmd.execute(state);
         assertTrue(result.contains("Completed: 164 / 160 MCs"));
         assertTrue(result.contains("Incomplete: 0 MCs"));
+        assertTrue(result.contains("(100.0%)"));
+        assertTrue(result.contains("0.0%)"));
+        assertFalse(result.contains("-"));
     }
 }


### PR DESCRIPTION
When a user exceeded the graduation total, the incomplete percentage was computed as 100 - completedPct, producing a negative value. Clamp the completed percentage at 100 and derive the incomplete percentage from the already-clamped remaining MCs so both values stay within [0, 100]. Strengthen the existing overflow test to guard the display.