### PR TITLE
Fix Command Summary table rendering in UG

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -466,6 +466,7 @@ CS2113 is not found in planner
 
 ---
 ## Command Summary
+
 | Action | Format                         | Example                   |
 |---|--------------------------------|---------------------------|
 | View all commands | `help`                         | `help`                    |


### PR DESCRIPTION
Add blank line between heading and table so MarkBind parses it as a table instead of inline text.