### PR TITLE
Fix error handling on planner add/edit with missing semester

### DIFF
--- a/src/main/java/seedu/pathlock/parser/Parser.java
+++ b/src/main/java/seedu/pathlock/parser/Parser.java
@@ -80,6 +80,9 @@ public class Parser {
                 }
                 String param = input.substring(4);
                 int seperator = param.indexOf(" ");
+                if (seperator == -1) {
+                    throw new MissingCommandException("Please input module code and semester after 'add '");
+                }
                 String moduleCode = param.substring(0, seperator).trim();
                 String semester = param.substring(seperator).trim();
                 return new AddToPlannerCommand(moduleCode,semester);
@@ -90,6 +93,9 @@ public class Parser {
                 }
                 String param = input.substring(5);
                 int seperator = param.indexOf(" ");
+                if (seperator == -1) {
+                    throw new MissingCommandException("Please input module code and semester after 'edit '");
+                }
                 String moduleCode = param.substring(0, seperator).trim();
                 String semester = param.substring(seperator).trim();
                 return new EditPlannerCommand(moduleCode, semester);


### PR DESCRIPTION
indexOf returned -1 when no space followed the module code, causing substring(0, -1) to throw StringIndexOutOfBoundsException. Throw MissingCommandException with a helpful hint instead.